### PR TITLE
Update config.toml according to the latest upstream version

### DIFF
--- a/conf/config.toml
+++ b/conf/config.toml
@@ -4,7 +4,7 @@ secret_key = "__KEY__"
 data_directory = "__DATA_DIR__"
 
 [server]
-host = 127.0.0.1
+host = "127.0.0.1"
 port = __PORT__
 allowed_hosts = ["__DOMAIN__"]
 trusted_proxies = ["127.0.0.1"]


### PR DESCRIPTION
Cf: https://readeck.org/en/blog/202411-readeck-16/#easier-to-run-behind-a-reverse-proxy