### PR TITLE
implement fail2ban for failed auths on login page and API endpoints

### DIFF
--- a/scripts/backup
+++ b/scripts/backup
@@ -25,6 +25,9 @@ ynh_backup "/etc/nginx/conf.d/$domain.d/$app.conf"
 
 ynh_backup "/etc/systemd/system/$app.service"
 
+ynh_backup "/etc/fail2ban/jail.d/$app.conf"
+ynh_backup "/etc/fail2ban/filter.d/$app.conf"
+
 #=================================================
 # BACKUP THE POSTGRESQL DATABASE
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -38,6 +38,8 @@ ynh_config_add --template="config.toml" --destination="$data_dir/config.toml"
 
 chmod 600 "$data_dir/config.toml"
 
+ynh_config_add_fail2ban --logpath="/var/log/nginx/${domain}-access.log" --failregex="<HOST> .*(GET|POST) (/login|/api.*) .* 401"
+
 #=================================================
 # START SYSTEMD SERVICE
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -38,7 +38,7 @@ ynh_config_add --template="config.toml" --destination="$data_dir/config.toml"
 
 chmod 600 "$data_dir/config.toml"
 
-ynh_config_add_fail2ban --logpath="/var/log/nginx/${domain}-access.log" --failregex="<HOST> .*(GET|POST) (/login|/api.*) .* 401"
+ynh_config_add_fail2ban --logpath="/var/log/nginx/${domain}-access.log" --failregex="<HOST> .*(GET|POST) (/login|/api.*|/opds.*) .* 401"
 
 #=================================================
 # START SYSTEMD SERVICE

--- a/scripts/remove
+++ b/scripts/remove
@@ -8,6 +8,8 @@ source /usr/share/yunohost/helpers
 #=================================================
 ynh_script_progression "Removing system configurations related to $app..."
 
+ynh_config_remove_fail2ban
+
 if ynh_hide_warnings yunohost service status "$app" >/dev/null; then
     yunohost service remove "$app"
 fi

--- a/scripts/restore
+++ b/scripts/restore
@@ -36,6 +36,10 @@ systemctl enable "$app.service" --quiet
 
 yunohost service add "$app" --description="Bookmark manager and a read later tool" --log="/var/log/$app/$app.log"
 
+ynh_restore "/etc/fail2ban/jail.d/$app.conf"
+ynh_restore "/etc/fail2ban/filter.d/$app.conf"
+ynh_systemctl --action=restart --service=fail2ban
+
 #=================================================
 # RELOAD NGINX AND PHP-FPM OR THE APP SERVICE
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -30,6 +30,8 @@ ynh_config_add_systemd
 
 yunohost service add "$app" --description="Bookmark manager and a read later tool" --log="/var/log/$app/$app.log"
 
+ynh_config_add_fail2ban --logpath="/var/log/nginx/${domain}-access.log" --failregex="<HOST> .*(GET|POST) (/login|/api.*) .* 401"
+
 #=================================================
 # UPDATE A CONFIG FILE
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -30,7 +30,7 @@ ynh_config_add_systemd
 
 yunohost service add "$app" --description="Bookmark manager and a read later tool" --log="/var/log/$app/$app.log"
 
-ynh_config_add_fail2ban --logpath="/var/log/nginx/${domain}-access.log" --failregex="<HOST> .*(GET|POST) (/login|/api.*) .* 401"
+ynh_config_add_fail2ban --logpath="/var/log/nginx/${domain}-access.log" --failregex="<HOST> .*(GET|POST) (/login|/api.*|/opds.*) .* 401"
 
 #=================================================
 # UPDATE A CONFIG FILE


### PR DESCRIPTION
tested OK

TODO:
- [x] implement the same fail2ban regex but for OPDS (`/opds`) https://codeberg.org/readeck/readeck/src/branch/main/docs/src/en-US/opds.md