### PR TITLE
Systemd hardening: Adds ReadWritePaths & removes useless comments

### DIFF
--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -14,6 +14,7 @@ RestartSec=5
 # Sandboxing options to harden security
 # Details for these options: https://www.freedesktop.org/software/systemd/man/systemd.exec.html
 ReadWritePaths=__INSTALL_DIR__ __DATA_DIR__
+MemoryDenyWriteExecute=true
 NoNewPrivileges=yes
 PrivateTmp=yes
 PrivateDevices=yes

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -11,10 +11,9 @@ ExecStart=__INSTALL_DIR__/readeck serve -config __DATA_DIR__/config.toml
 Restart=on-failure
 RestartSec=5
 
-### Depending on specificities of your service/app, you may need to tweak these
-### .. but this should be a good baseline
 # Sandboxing options to harden security
 # Details for these options: https://www.freedesktop.org/software/systemd/man/systemd.exec.html
+ReadWritePaths=__INSTALL_DIR__ __DATA_DIR__
 NoNewPrivileges=yes
 PrivateTmp=yes
 PrivateDevices=yes


### PR DESCRIPTION
I saw `ReadWritePaths` in the deploy page and thought about adding it here
https://readeck.org/en/docs/deploy