### PR TITLE
Change proxy parameters to include authentication

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -3,7 +3,7 @@ location __PATH__/ {
 
   proxy_pass http://127.0.0.1:__PORT__;
 
-  include proxy_params_no_auth;
+  include proxy_params_with_auth;
   proxy_redirect off;
   proxy_buffering off;
   client_max_body_size 50M;


### PR DESCRIPTION
I could not authenticate with API token.
`curl -v -H "Authorization: Bearer <token>" https://myreadeckdomain.fr/api/profile` returned a 401 Unauthorized. This prevents the use of third-party app since Readeck removed basic auth.

Another Go app, [Miniflux](https://github.com/YunoHost-Apps/miniflux_ynh/tree/master), works with token. So I compared the configuration of the two apps and noticed a difference in nginx.conf. I tried installing Readeck with `include proxy_params_with_auth;` instead of include `proxy_params_no_auth;`, and the tokens now work and I can use third-party apps.

Note that I've no idea what this changes behind the scene.

This PR fixes #75 for me.